### PR TITLE
Upgrade FFI Dependency

### DIFF
--- a/http-parser.gemspec
+++ b/http-parser.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
   EOF
 
 
-  s.add_dependency 'ffi-compiler', '>= 1.0', '< 2.0'
+  s.add_dependency 'ffi-compiler', '>= 1.13.1', '< 2.0'
 
   s.add_development_dependency 'rake',  '~> 11.2'
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'yard',  '~> 0.9'
-  
+
 
   s.files = Dir["{lib}/**/*"] + %w(Rakefile http-parser.gemspec README.md LICENSE)
   s.files += ["ext/http-parser/http_parser.c", "ext/http-parser/http_parser.h"]


### PR DESCRIPTION
This patch upgrade the minimum version of FFI to be `1.13.1`.
We recently run into segfaults with http-parser 1.2.1 (latest rubygems release) with ruby 2.7.
Those segfaults were caused by the newly introduced Compacting GC but they are fixed in the 1.13.1 release of ffi.

Issue on FFI: https://github.com/ffi/ffi/issues/742
Fixing commit: https://github.com/ffi/ffi/commit/6662bccd0bff2f64b79380e23850548af76637b7