### PR TITLE
Support installing on Apple Silicon Macs

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -3,6 +3,4 @@ require 'ffi-compiler/compile_task'
 FFI::Compiler::CompileTask.new('http-parser-ext') do |t|
   t.cflags << "-Wall -Wextra -O3"
   t.cflags << "-D_GNU_SOURCE=1" if RbConfig::CONFIG["host_os"].downcase =~ /mingw/
-  t.cflags << "-arch x86_64" if t.platform.mac?
-  t.ldflags << "-arch x86_64" if t.platform.mac?
 end


### PR DESCRIPTION
Hi Team,

Hope all is going well.

The ext Rakefile currently assumes an x86 architecture for mac targets which prevents building an arm64 native bundle on an Apple Silicon Mac.

This PR removes that assumption - building for either platform now uses the right architecture:

ie. Intel Mac:

```
➜  http-parser git:(feature/remove-explicit-x86) ✗ file /Users/crafterm/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/http-parser-1.2.2/ext/x86_64-darwin/libhttp-parser-ext.bundle
/Users/crafterm/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/http-parser-1.2.2/ext/x86_64-darwin/libhttp-parser-ext.bundle: Mach-O 64-bit bundle x86_64
```

ie. Apple Silicon Mac
```
➜  http-parser git:(feature/remove-explicit-x86) ✗ file /Users/crafterm/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/http-parser-1.2.2/ext/arm-darwin/libhttp-parser-ext.bundle
/Users/crafterm/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/http-parser-1.2.2/ext/arm-darwin/libhttp-parser-ext.bundle: Mach-O 64-bit bundle arm64
```

Cheers,

M!