### PR TITLE
Revert "Upgrade FFI Dependency"

### DIFF
--- a/http-parser.gemspec
+++ b/http-parser.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
   EOF
 
 
-  s.add_dependency 'ffi-compiler', '>= 1.13.1', '< 2.0'
+  s.add_dependency 'ffi-compiler', '>= 1.0', '< 2.0'
 
   s.add_development_dependency 'rake',  '~> 11.2'
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'yard',  '~> 0.9'
-
+  
 
   s.files = Dir["{lib}/**/*"] + %w(Rakefile http-parser.gemspec README.md LICENSE)
   s.files += ["ext/http-parser/http_parser.c", "ext/http-parser/http_parser.h"]


### PR DESCRIPTION
Reverts cotag/http-parser#7

Resolves cotag/http-parser#9

The changes to the ffi-compiler dependency are invalid, as ffi-compiler does not exceed 1.0.1, so this dep will always fail.
Not sure of original authors intent, but this does nothing other than break the build, so requesting its reversion.

https://rubygems.org/gems/ffi-compiler

@Jcambass FYI, maybe you wanted to add an ffi dep instead of ffi-compiler?